### PR TITLE
Part5:  Display list pages

### DIFF
--- a/loccallibrary/src/config/data-source.ts
+++ b/loccallibrary/src/config/data-source.ts
@@ -10,7 +10,7 @@ export const AppDataSource = new DataSource({
   port: parseInt(process.env.DB_PORT || "3306"),
   username: process.env.DB_USERNAME,
   password: process.env.DB_PASSWORD,
-  database: process.env.DATABASE,
+  database: process.env.DB_NAME,
   logging: false,
   migrations: [join(__dirname, "/../migration/**{.ts,.js}")],
   entities: [join(__dirname, "/../**/**.entity{.ts,.js}")],

--- a/loccallibrary/src/controllers/author.controller.ts
+++ b/loccallibrary/src/controllers/author.controller.ts
@@ -1,9 +1,11 @@
 ﻿import { Request, Response } from "express";
 import asyncHandler from "express-async-handler";
+import { listAuthors } from "../services/author.service";
 
 // Display list of all Authors.
 export const authorList = asyncHandler(async (req: Request, res: Response) => {
-  res.send("NOT IMPLEMENTED: Author list");
+  const authors = await listAuthors();
+  res.render("authors/author", { authors });
 });
 
 // Display detail page for a specific Author.

--- a/loccallibrary/src/controllers/book.controller.ts
+++ b/loccallibrary/src/controllers/book.controller.ts
@@ -12,7 +12,7 @@ import { numberOfGenres } from "../services/genre.service";
 //p5
 export const bookList = asyncHandler(async (req: Request, res: Response) => {
   const books = await findBook();
-  res.render("books/list", { books, title: "List of books" });
+  res.render("books/index", { books });
 });
 
 // Display detail page for a specific book.

--- a/loccallibrary/src/controllers/bookInstance.controller.ts
+++ b/loccallibrary/src/controllers/bookInstance.controller.ts
@@ -1,10 +1,14 @@
 ﻿import { Request, Response } from "express";
 import asyncHandler from "express-async-handler";
+import { listBookInstances } from "../services/bookInstance.service";
 
 // Display list of all bookInstances.
 export const bookInstanceList = asyncHandler(
   async (req: Request, res: Response) => {
-    res.send("NOT IMPLEMENTED: bookInstance list");
+    const bookInstances = await listBookInstances();
+    res.render("bookinstances/bookinstance", {
+      bookInstances,
+    });
   }
 );
 

--- a/loccallibrary/src/controllers/genre.controller.ts
+++ b/loccallibrary/src/controllers/genre.controller.ts
@@ -1,9 +1,11 @@
 ﻿import { Request, Response } from "express";
 import asyncHandler from "express-async-handler";
+import { listGenres } from "../services/genre.service";
 
 // Display list of all genres.
 export const genreList = asyncHandler(async (req: Request, res: Response) => {
-  res.send("NOT IMPLEMENTED: genre list");
+  const genres = await listGenres();
+  res.render("genres/genre", { genres });
 });
 
 // Display detail page for a specific genre.

--- a/loccallibrary/src/locales/en/translation.json
+++ b/loccallibrary/src/locales/en/translation.json
@@ -19,5 +19,22 @@
     "create_bookinstance": "Create book instances",
     "english_translations": "English",
     "vietnamese_translations": "Vietnamese"
+  },
+
+  "author": {
+    "title": "Author List",
+    "no_author": "There are no author"
+  },
+  "genre": {
+    "title": "Genre List",
+    "no_genre": "There are no genre"
+  },
+  "bookinstance": {
+    "title": "Book Instance List",
+    "no_bookinstance": "There are no book instance"
+  },
+  "book": {
+    "title": "Book List",
+    "no_book": "There are no book"
   }
 }

--- a/loccallibrary/src/locales/vi/translation.json
+++ b/loccallibrary/src/locales/vi/translation.json
@@ -19,5 +19,21 @@
     "create_bookinstance": "Tạo mới bản sao sách",
     "english_translations": "Tiếng Anh",
     "vietnamese_translations": "Tiếng Việt"
+  },
+  "author": {
+    "title": "Danh sách tác giả",
+    "no_author": "Không có tác giả"
+  },
+  "genre": {
+    "title": "Danh sách thể loại",
+    "no_genre": "Không có thể loại"
+  },
+  "bookinstance": {
+    "title": "Danh sách bản sao sách",
+    "no_bookinstance": "Không có bản sao sách"
+  },
+  "book": {
+    "title": "Danh sách sách",
+    "no_book": "Không có sách"
   }
 }

--- a/loccallibrary/src/services/author.service.ts
+++ b/loccallibrary/src/services/author.service.ts
@@ -7,3 +7,10 @@ export const numberOfAuthors = async () => {
   const authors = await authorRepository.count();
   return authors;
 };
+
+export const listAuthors = async () => {
+  return await authorRepository.find({
+    order: { firstName: "ASC" },
+    relations: ["books"],
+  });
+};

--- a/loccallibrary/src/services/book.service.ts
+++ b/loccallibrary/src/services/book.service.ts
@@ -16,3 +16,10 @@ export const numberOfBooks = async () => {
 
   return books;
 };
+
+export const findById = async (id) => {
+  return await bookRepository.findOne({
+    relations: ["author", "genres", "bookInstances"],
+    where: { id: id },
+  });
+};

--- a/loccallibrary/src/services/bookInstance.service.ts
+++ b/loccallibrary/src/services/bookInstance.service.ts
@@ -14,3 +14,9 @@ export const availableBookInstances = async () => {
   });
   return bookInstances;
 };
+
+export const listBookInstances = async () => {
+  return await bookInstanceRepository.find({
+    relations: ["book"],
+  });
+};

--- a/loccallibrary/src/services/genre.service.ts
+++ b/loccallibrary/src/services/genre.service.ts
@@ -4,6 +4,12 @@ import { Genre } from "../entity/genre.entity";
 const genreRepository = AppDataSource.getRepository(Genre);
 
 export const numberOfGenres = async () => {
-  const genres = genreRepository.count();
+  const genres = await genreRepository.count();
   return genres;
+};
+
+export const listGenres = async () => {
+  return await genreRepository.find({
+    order: { name: "ASC" },
+  });
 };

--- a/loccallibrary/src/views/authors/author.pug
+++ b/loccallibrary/src/views/authors/author.pug
@@ -1,0 +1,50 @@
+extends ../layout
+
+block content
+  div(class='container-fluid')
+    div(class='row') 
+      div(class='col-sm-2')
+        block sidebar
+          ul(class='sidebar-nav')
+            li
+              a(href='/') #{t('home.local_library')}
+            li
+              a(href='/books/list') #{t('home.book')}
+            li
+              a(href='/authors/list') #{t('home.author')}
+            li
+              a(href='/genres/list') #{t('home.genre')}
+            li
+              a(href='/bookInstances/list') #{t('home.book_instance')}
+
+      hr()
+
+      div(class='col-sm-2')
+        block sidebar
+          ul(class='sidebar-nav')
+            li
+              a(href='/authors/create') #{t('home.create_author')}
+            li
+              a(href='/genres/create') #{t('home.create_genre')}
+            li
+              a(href='/books/create') #{t('home.create_book')}
+            li
+              a(href='/bookInstances/create') #{t('home.create_bookinstance')}
+      div(class='row-sm-2')
+        block sidebar
+          ul(class='sidebar-nav')
+            li(class='inline')
+              a(href='/authors/list/?lang=en') #{t('home.english_translations')}
+            li(class='inline-between') 
+              p |
+            li(class='inline') 
+              a(href='/authors/list/?lang=vi') #{t('home.vietnamese_translations')}
+            .content
+              h1 #{t('author.title')}
+              ul
+                each author in authors
+                  li
+                    a(href=author.url) #{author.name}
+                    |     ( #{author.dateOfBirth} - #{author.dateOfDeath}) 
+              if authors.length === 0
+                p #{t('author.no_author')}

--- a/loccallibrary/src/views/bookinstances/bookinstance.pug
+++ b/loccallibrary/src/views/bookinstances/bookinstance.pug
@@ -1,0 +1,53 @@
+extends ../layout
+
+block content
+  div(class='container-fluid')
+    div(class='row') 
+      div(class='col-sm-2')
+        block sidebar
+          ul(class='sidebar-nav')
+            li
+              a(href='/') #{t('home.local_library')}
+            li
+              a(href='/books/list') #{t('home.book')}
+            li
+              a(href='/authors/list') #{t('home.author')}
+            li
+              a(href='/genres/list') #{t('home.genre')}
+            li
+              a(href='/bookInstances/list') #{t('home.book_instance')}
+
+      hr()
+
+      div(class='col-sm-2')
+        block sidebar
+          ul(class='sidebar-nav')
+            li
+              a(href='/authors/create') #{t('home.create_author')}
+            li
+              a(href='/genres/create') #{t('home.create_genre')}
+            li
+              a(href='/books/create') #{t('home.create_book')}
+            li
+              a(href='/bookInstances/create') #{t('home.create_bookinstance')}
+      div(class='row-sm-2')
+        block sidebar
+          ul(class='sidebar-nav')
+            li(class='inline')
+              a(href='/bookInstances/list/?lang=en') #{t('home.english_translations')}
+            li(class='inline-between') 
+              p |
+            li(class='inline') 
+              a(href='/bookInstances/list/?lang=vi') #{t('home.vietnamese_translations')}
+            .content
+      h1 #{t('bookinstance.title')}
+      if bookInstances.length
+        ul
+          each bookInstance in bookInstances
+            li
+              a(href=bookInstance.url) #{bookInstance.book.title} #{bookInstance.imprint}
+              span  - #{bookInstance.status}
+                if bookInstance.status != 'Available'
+                  span  (Due back: #{bookInstance.due_back})
+      else
+        p #{t('bookinstance.no_bookinstance')}

--- a/loccallibrary/src/views/books/book.pug
+++ b/loccallibrary/src/views/books/book.pug
@@ -1,0 +1,50 @@
+extends ../layout
+
+block content
+  div(class='container-fluid')
+    div(class='row') 
+      div(class='col-sm-2')
+        block sidebar
+          ul(class='sidebar-nav')
+            li
+              a(href='/') #{t('home.local_library')}
+            li
+              a(href='/books/list') #{t('home.book')}
+            li
+              a(href='/authors/list') #{t('home.author')}
+            li
+              a(href='/genres/list') #{t('home.genre')}
+            li
+              a(href='/bookInstances/list') #{t('home.book_instance')}
+
+      hr()
+
+      div(class='col-sm-2')
+        block sidebar
+          ul(class='sidebar-nav')
+            li
+              a(href='/authors/create') #{t('home.create_author')}
+            li
+              a(href='/genres/create') #{t('home.create_genre')}
+            li
+              a(href='/books/create') #{t('home.create_book')}
+            li
+              a(href='/bookInstances/create') #{t('home.create_bookinstance')}
+      div(class='row-sm-2')
+        block sidebar
+          ul(class='sidebar-nav')
+            li(class='inline')
+              a(href='/books/list/?lang=en') #{t('home.english_translations')}
+            li(class='inline-between') 
+              p |
+            li(class='inline') 
+              a(href='/books/list/?lang=vi') #{t('home.vietnamese_translations')}
+            .content
+              h1 #{t('book.title')}
+              ul
+                each book in books
+                  li
+                    a(href=book.url) #{book.title}
+                    |   (#{book.author.name})
+              if books.length === 0
+                p #{t('book.no_book')}

--- a/loccallibrary/src/views/genres/genre.pug
+++ b/loccallibrary/src/views/genres/genre.pug
@@ -1,0 +1,50 @@
+extends ../layout
+
+block content
+  div(class='container-fluid')
+    div(class='row') 
+      div(class='col-sm-2')
+        block sidebar
+          ul(class='sidebar-nav')
+            li
+              a(href='/') #{t('home.local_library')}
+            li
+              a(href='/books/list') #{t('home.book')}
+            li
+              a(href='/authors/list') #{t('home.author')}
+            li
+              a(href='/genres/list') #{t('home.genre')}
+            li
+              a(href='/bookInstances/list') #{t('home.book_instance')}
+
+      hr()
+
+      div(class='col-sm-2')
+        block sidebar
+          ul(class='sidebar-nav')
+            li
+              a(href='/authors/create') #{t('home.create_author')}
+            li
+              a(href='/genres/create') #{t('home.create_genre')}
+            li
+              a(href='/books/create') #{t('home.create_book')}
+            li
+              a(href='/bookInstances/create') #{t('home.create_bookinstance')}
+      div(class='row-sm-2')
+        block sidebar
+          ul(class='sidebar-nav')
+            li(class='inline')
+              a(href='/genres/list/?lang=en') #{t('home.english_translations')}
+            li(class='inline-between') 
+              p |
+            li(class='inline') 
+              a(href='/genres/list/?lang=vi') #{t('home.vietnamese_translations')}
+            .content
+              h1 #{t('genre.title')}
+              ul
+                each genre in genres
+                  li
+                    a(href=genre.url) #{genre.name}
+
+              if genres.length === 0
+                p #{t('genre.no_genre')}


### PR DESCRIPTION
## Checklist tự review pull trước khi ready để trainer review

- [v] Kiểm tra mỗi pull request chỉ 1 commit, nếu nhiều hơn 1 commit thì hãy gộp commit thành 1 rồi đẩy lại lên git
- [v] Chạy eslint ở local để check và fix các lỗi liên quan đến syntax, coding convention. Khi gửi thì chụp ảnh PASS eslint đính kèm trong pull
- [v] Sử dụng thụt lề 2 spaces/4 spaces đồng nhất ở tất cả các files (setting lại vscode /sublime text nếu chưa cài đặt)
- [v] Cuối mỗi file kiểm tra có end line (khi đẩy lên git xem file change không bị lỗi tròn đỏ ở cuối file)
- [v] Mỗi dòng nếu quá dài, cần xuống dòng (maximum: 80 kí tự mỗi dòng, setting trong IDE hoặc dùng Prettier để config format code)
- [v] Tham khảo Typescript coding convention https://google.github.io/styleguide/tsguide.html

## Related Tickets

- ticket redmine

## WHAT (optional)

- Change number items `completed/total` in admin page.

## HOW

- I edit js file, inject not_vary_normal items in calculate function.

## WHY (optional)

- Because in previous version - number just depends on `normal` items. But in new version, we have `state` and `confirm_state` depends on both `normal` + `not_normal` items.

## Evidence (Screenshot or Video)
![image](https://github.com/user-attachments/assets/cb4bc1db-d339-4cfa-99c3-d0bf06894889)


## Notes (Kiến thức tìm hiểu thêm)
